### PR TITLE
Add JSEX.Encoder implementation to HashDict

### DIFF
--- a/lib/jsex.ex
+++ b/lib/jsex.ex
@@ -107,6 +107,10 @@ defprotocol JSEX.Encoder do
   def json(term)
 end
 
+defimpl JSEX.Encoder, for: HashDict do
+  def json(dict), do: JSEX.Encoder.json(HashDict.to_list(dict))
+end
+
 defimpl JSEX.Encoder, for: List do
   def json([]), do: [:start_array, :end_array]
   def json([{}]), do: [:start_object, :end_object]

--- a/test/jsex_test.exs
+++ b/test/jsex_test.exs
@@ -146,7 +146,15 @@ defmodule JSEX.Tests.Encode do
   test "encode! keylist" do
     assert(JSEX.encode!([key: true]) == "{\"key\":true}")
   end
-  
+
+  test "encode HashDict" do
+    assert(JSEX.encode(HashDict.new(key: true)) == { :ok, "{\"key\":true}" })
+  end
+
+  test "encode! HashDict" do
+    assert(JSEX.encode!(HashDict.new(key: true)) == "{\"key\":true}")
+  end
+
   test "encode object with bitstring key" do
     assert(JSEX.encode([{"key", true}]) == { :ok, "{\"key\":true}" })
   end


### PR DESCRIPTION
This is really simple solution to encode HashDicts. Basically we reuse the implementation of list of keys/values.

It closes #10.
