### PR TITLE
Update to Elixir v0.10.0

### DIFF
--- a/lib/jsex.ex
+++ b/lib/jsex.ex
@@ -128,7 +128,7 @@ defimpl JSEX.Encoder, for: Tuple do
       JSEX.Encoder.json Enum.map(
         record.__record__(:fields),
         fn({ key, _ }) ->
-          index = record.__index__(key)
+          index = record.__record__(:index, key)
           value = elem(record, index)
           { key, value }
         end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-[ "jsx": {:git,"https://github.com/talentdeficit/jsx.git","352d6b21cbec4fe1b66bc7ce3ded67a3b32add2c",[tag: "v1.4.2"]} ]
+[ "jsx": {:git,"git://github.com/talentdeficit/jsx.git","352d6b21cbec4fe1b66bc7ce3ded67a3b32add2c",[tag: "v1.4.2"]} ]


### PR DESCRIPTION
- Record.**index** was deprecated
- git:// to default mix.lock
