### PR TITLE
Replace Number with Float/Integer for JSEX.Encoder protocol

### DIFF
--- a/lib/jsex.ex
+++ b/lib/jsex.ex
@@ -103,7 +103,6 @@ defmodule JSEX.Decoder do
 end
 
 defprotocol JSEX.Encoder do
-  @only [Record, List, Tuple, Atom, Integer, Float, BitString, Any]
   def json(term)
 end
 
@@ -156,10 +155,10 @@ defimpl JSEX.Encoder, for: Atom do
   def json(_), do: raise ArgumentError
 end
 
-defimpl JSEX.Encoder, for: [Integer, Float, BitString] do
+defimpl JSEX.Encoder, for: [Number, Integer, Float, BitString] do
   def json(value), do: [value]
 end
 
-defimpl JSEX.Encoder, for: Any do
+defimpl JSEX.Encoder, for: [PID, Any] do
   def json(_), do: raise ArgumentError
 end


### PR DESCRIPTION
Hi. elixir/master is now splitting number into integer and float in protocols with the following commit.

https://github.com/elixir-lang/elixir/commit/ea9b0e07daca100dd78dd2e257b21f305d125c5f

Then, JSEX.encode for numbers are failing with "argument error". It is intended to avoid the error by adding Float/Integer protocol.

``` Shell
tmp/github/jsex[master]% iex -S mix
Erlang R16B01 (erts-5.10.2) [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Interactive Elixir (0.10.4-dev) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> JSEX.encode!([0])
** (ArgumentError) argument error
    lib/jsex.ex:164: JSEX.Encoder.Any.json/1
    lib/jsex.ex:129: JSEX.Encoder.List."-json/1-lc$^3/1-0-"/1
    lib/jsex.ex:129: JSEX.Encoder.List.json/1
    lib/jsex.ex:6: JSEX.encode!/2
```
