### PR TITLE
Remove support for deprecated modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: elixir
-elixir: 1.0.5
+elixir: 1.4.1
 otp_release:
-  - 17.5
-  - 18.0
+  - 19.0

--- a/lib/jsx.ex
+++ b/lib/jsx.ex
@@ -68,15 +68,15 @@ defmodule JSX do
   rescue
     _ -> false
   end
-  
+
   def encoder(handler, initialstate, opts) do
     :jsx.encoder(handler, initialstate, opts)
   end
-  
+
   def decoder(handler, initialstate, opts) do
     :jsx.decoder(handler, initialstate, opts)
   end
-  
+
   def parser(handler, initialstate, opts) do
     :jsx.parser(handler, initialstate, opts)
   end
@@ -139,14 +139,12 @@ defimpl JSX.Encoder, for: [Integer, Float, BitString] do
   def json(value), do: [value]
 end
 
-defimpl JSX.Encoder, for: HashDict do
-  def json(dict), do: JSX.Encoder.json(HashDict.to_list(dict))
+defimpl JSX.Encoder, for: [Range, Stream] do
+  def json(enumerable), do: enumerable |> Enum.to_list |> JSX.Encoder.json
 end
 
-defimpl JSX.Encoder, for: [Range, Stream, HashSet] do
-  def json(enumerable) do
-    JSX.Encoder.json(Enum.to_list(enumerable))
-  end
+defimpl JSX.Encoder, for: MapSet do
+  def json(enumerable), do: enumerable |> Enum.sort |> JSX.Encoder.json
 end
 
 defimpl JSX.Encoder, for: [Tuple, PID, Port, Reference, Function, Any] do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []}}
+%{"earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "jsx": {:hex, :jsx, "2.8.1", "1453b4eb3615acb3e2cd0a105d27e6761e2ed2e501ac0b390f5bbec497669846", [:mix, :rebar3], []}}

--- a/test/jsx_test.exs
+++ b/test/jsx_test.exs
@@ -171,20 +171,12 @@ defmodule JSX.Tests.Encode do
     assert(JSX.encode!(0..9) == "[0,1,2,3,4,5,6,7,8,9]")
   end
 
-  test "encode HashSet" do
-    assert(JSX.encode(Enum.into([1, 2, 3], HashSet.new)) == { :ok, "[2,3,1]" })
+  test "encode MapSet as sorted array" do
+    assert(JSX.encode(Enum.into([2, 1, 3], MapSet.new)) == { :ok, "[1,2,3]" })
   end
 
-  test "encode! HashSet" do
-    assert(JSX.encode!(Enum.into([1, 2, 3], HashSet.new)) == "[2,3,1]")
-  end
-
-  test "encode HashDict" do
-    assert(JSX.encode(Enum.into([key: true], HashDict.new)) == { :ok, "{\"key\":true}" })
-  end
-
-  test "encode! HashDict" do
-    assert(JSX.encode!(Enum.into([key: true], HashDict.new)) == "{\"key\":true}")
+  test "encode! MapSet as sorted array" do
+    assert(JSX.encode!(Enum.into([2, 1, 3], MapSet.new)) == "[1,2,3]")
   end
 
   test "encode object with bitstring key" do
@@ -210,17 +202,13 @@ defmodule JSX.Tests.Encode do
   test "encode! compound object" do
     assert(JSX.encode!(compoundobj(:ex)) == compoundobj(:json))
   end
-  
+
   test "encode keylist with key `nil`" do
     assert(JSX.encode([nil: nil]) == { :ok, "{\"nil\":null}" })
   end
-  
+
   test "encode map with key `nil`" do
     assert(JSX.encode(%{ nil => nil }) == { :ok, "{\"nil\":null}" })
-  end
-  
-  test "encode HashDict with key `nil`" do
-    assert(JSX.encode(Enum.into([nil: nil], HashDict.new)) == { :ok, "{\"nil\":null}" })
   end
 end
 


### PR DESCRIPTION
This PR removes warnings and removes support for deprecated modules. I suggest a major version bump.

- Update deps to remove Elixir 1.4 compiler warnings
- Remove support for deprecated modules `HashDict` and `HashSet`.
- Add support for `MapSet`.
- Also adds sorting to `MapSet` JSON representation. Not sure this is needed/desired but the existing tests relied on order.

