### PR TITLE
Relax the dependency requirement on jsx

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule EXJSX.Mixfile do
   end
 
   defp deps do
-    [{:jsx, "~> 2.8.0"}, {:ex_doc, "~> 0.14", only: :dev}]
+    [{:jsx, "~> 2.8"}, {:ex_doc, "~> 0.14", only: :dev}]
   end
 
   defp description do


### PR DESCRIPTION
The current dependency on jsx is quite strict and doesn't work well with packages that require 2.9 (e.g. https://github.com/pma/amqp).

In relaxing the requirement there shouldn't be any problem for people depending on 2.8 and it would allow to use 2.9 as well.